### PR TITLE
Use ref to uniquely identify container

### DIFF
--- a/src/SVGAnimator.js
+++ b/src/SVGAnimator.js
@@ -13,36 +13,26 @@ import Snapsvg from 'snapsvg-cjs';
 /* eslint-enable */
 
 //snap.json is located in the public folder, dev-build folder(ugly approach).
-let jsonfile = "snap.json";
 
 class SVGAnimator extends Component {
 
-  constructor(props){
-    super(props);
-    this.state = {
-      data: ''
-    }
-  }
   componentDidMount(){
-    axios.get(jsonfile)
+    axios.get(this.props.jsonfile)
       .then(response => {
-        this.setState({ data: response.data })
+        this.getSVG(response.data)
       });
   }
 
-  getSVG(){
-    if(this.state.data){
-      const container = document.getElementById('container');
-      const SVG = new window.SVGAnim(this.state.data, 269, 163, 24)
-      container.appendChild(SVG.s.node);
+  getSVG(svgData){
+    if(svgData){
+      const SVG = new window.SVGAnim(svgData, this.props.width, this.props.height, this.props.framerate)
+      this.svgContainer.appendChild(SVG.s.node);
     }
   }
 
   render() {
     return (
-      <div id="container">
-        { this.getSVG()}
-      </div>
+      <div ref={(container) => { this.svgContainer = container; }} />
     );
   }
 }


### PR DESCRIPTION
We stop using a div id to identify our container, so that we can use more than one component on a page. 

Also, pass in parameters like the json path to the component to make it more re-usable. Now we can create multiple components on the same page, like so:
```
<SVGAnimator jsonfile='snap_1.json' width='319' height='634' framerate='24' />
 <SVGAnimator jsonfile='snap_2.json' width='270' height='263' framerate='24' />
```